### PR TITLE
fix: use correct ns label name for kube-system

### DIFF
--- a/packages/server/src/k8s/challenge/manifest.js
+++ b/packages/server/src/k8s/challenge/manifest.js
@@ -53,7 +53,13 @@ export const makeNetworkPolicies = ({
           to: [{ namespaceSelector: { matchLabels: commonLabels } }],
         },
         {
-          to: [{ namespaceSelector: { matchLabels: { name: 'kube-system' } } }],
+          to: [
+            {
+              namespaceSelector: {
+                matchLabels: { 'kubernetes.io/metadata.name': 'kube-system' },
+              },
+            },
+          ],
           ports: [
             {
               protocol: 'UDP',


### PR DESCRIPTION
fixes #3