### PR TITLE
Update traefik namespace for compatibility with v3

### DIFF
--- a/manifests/klodd-rbac.yaml
+++ b/manifests/klodd-rbac.yaml
@@ -15,7 +15,7 @@ rules:
   - apiGroups: [networking.k8s.io]
     resources: [networkpolicies]
     verbs: [create, delete]
-  - apiGroups: [traefik.containo.us]
+  - apiGroups: [traefik.io]
     resources: [ingressroutes, ingressroutetcps, middlewares, middlewaretcps]
     verbs: [create, delete]
   - apiGroups: [klodd.tjcsec.club]

--- a/packages/server/src/k8s/instance.js
+++ b/packages/server/src/k8s/instance.js
@@ -163,7 +163,7 @@ export const createInstance = async (challengeId, teamId, log) => {
         challengeConfig.middlewares.map(makeMiddleware).map((middleware) =>
           customApi
             .createNamespacedCustomObject(
-              'traefik.containo.us',
+              'traefik.io',
               'v1alpha1',
               namespace,
               middlewarePlural,
@@ -194,7 +194,7 @@ export const createInstance = async (challengeId, teamId, log) => {
     })
     await customApi
       .createNamespacedCustomObject(
-        'traefik.containo.us',
+        'traefik.io',
         'v1alpha1',
         namespace,
         ingressPlural,

--- a/packages/server/src/k8s/manifest.js
+++ b/packages/server/src/k8s/manifest.js
@@ -160,7 +160,7 @@ export const makeServiceFactory =
 export const makeIngressRouteFactory =
   (kind) =>
   ({ host, serviceName, servicePort, numMiddlewares }) => ({
-    apiVersion: 'traefik.containo.us/v1alpha1',
+    apiVersion: 'traefik.io/v1alpha1',
     kind: kind === 'http' ? 'IngressRoute' : 'IngressRouteTCP',
     metadata: { name: 'ingress' },
     spec: {
@@ -190,7 +190,7 @@ export const makeIngressRouteFactory =
   })
 
 export const makeMiddlewareFactory = (kind) => (middleware, idx) => ({
-  apiVersion: 'traefik.containo.us/v1alpha1',
+  apiVersion: 'traefik.io/v1alpha1',
   kind: kind === 'http' ? 'Middleware' : 'MiddlewareTCP',
   metadata: { name: `middleware-${idx}` },
   spec: middleware,


### PR DESCRIPTION
Traefik changed its API group from `traefik.containo.us` to `traefik.io` and only the latter works as of v3, this change is the only thing needed for it to work with more recent Traefik releases.